### PR TITLE
Added `FieldExt`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,11 @@ after_success: |
     make install DESTDIR=../../kcov-build &&
     cd ../.. &&
     rm -rf kcov-master &&
-    for file in target/debug/proc_macro_roids-*; do [ -x "${file}" ] || continue; mkdir -p "target/cov/$(basename $file)"; ./kcov-build/usr/local/bin/kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
+    for file in target/debug/proc_macro_roids-*
+    do [ -x "${file}" ] || continue
+    mkdir -p "target/cov/$(basename $file)"
+    ./kcov-build/usr/local/bin/kcov --exclude-pattern=/.cargo,/usr/lib --exclude-line=kcov-ignore --exclude-region=kcov-ignore-start:kcov-ignore-end --verify "target/cov/$(basename $file)" "$file"
+    done &&
     bash <(curl -s https://codecov.io/bash) &&
     echo "Uploaded code coverage"
   fi

--- a/README.md
+++ b/README.md
@@ -10,6 +10,70 @@ Traits and functions to make writing proc macros more ergonomic.
 The *roids* name is chosen because, although these functions make it easy to perform certain
 operation, they may not necessarily be a good idea =D!
 
+Makes writing procedural macros much easier:
+
+```rust
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use proc_macro_roids::{DeriveInputStructExt, FieldExt, IdentExt};
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput, Ident};
+
+/// Derives a `Super` implementation:
+///
+/// ```rust,edition2018
+/// use std::marker::PhantomData;
+/// use super_derive::Super;
+///
+/// #[derive(Super)]
+/// pub struct Man<T> {
+///     #[super_derive(skip)]
+///     name: String,
+///     power_level: u64,
+///     marker: PhantomData<T>,
+/// }
+/// ```
+///
+/// Generates:
+///
+/// ```rust,ignore
+/// pub enum SuperMan {
+///     U64(u64),
+/// }
+/// ```
+#[proc_macro_derive(Super, attributes(super_derive))]
+pub fn system_desc_derive(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let enum_name = ast.ident.prepend("Super");
+    let fields = ast.fields();
+    let relevant_fields = fields
+        .iter()
+        .filter(|field| !field.is_phantom_data())
+        .filter(|field| !field.contains_tag("super_derive", "skip"));
+
+    let variants = relevant_fields
+        .map(|field| {
+            let type_name = field.type_name();
+            let variant_name = type_name.to_string().to_uppercase();
+            let variant_name = Ident::new(&variant_name, Span::call_site());
+            quote! {
+                #variant_name(#type_name)
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let token_stream2 = quote! {
+        pub enum #enum_name {
+            #(#variants,)*
+        }
+    };
+
+    token_stream2.into()
+}
+```
+
 ## Examples
 
 1. Append additional `#[derive(..)]`s.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,43 @@ operation, they may not necessarily be a good idea =D!
     # }
     ```
 
+6. Accessing struct fields.
+
+    ```rust,edition2018
+    use proc_macro_roids::DeriveInputStructExt;
+    use syn::{parse_quote, DeriveInput, Fields};
+
+    # fn main() {
+    let ast: DeriveInput = parse_quote! {
+        struct Named {}
+    };
+
+    if let Fields::Named(..) = ast.fields() {
+        // do something
+    }
+    # }
+    ```
+
+7. Inspecting `Field`s.
+
+    ```rust,edition2018
+    use proc_macro_roids::FieldExt;
+    use syn::{parse_quote, Fields, FieldsNamed};
+
+    # fn main() {
+    let fields_named: FieldsNamed = parse_quote! {{
+        #[my_derive(tag_name)]
+        pub name: PhantomData<T>,
+    }};
+    let fields = Fields::from(fields_named);
+    let field = fields.iter().next().expect("Expected field to exist.");
+
+    assert_eq!(field.type_name(), "PhantomData");
+    assert!(field.is_phantom_data());
+    assert!(field.contains_tag("my_derive", "tag_name"));
+    # }
+    ```
+
 ## License
 
 Licensed under either of

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+merge_imports = true

--- a/src/derive_input_newtype_ext.rs
+++ b/src/derive_input_newtype_ext.rs
@@ -62,7 +62,9 @@ impl DeriveInputNewtypeExt for DeriveInput {
                     .iter_mut()
                     .next()
                     .expect("Expected field to exist.")
+            // kcov-ignore-start
             } else {
+                // kcov-ignore-end
                 panic!(NEWTYPE_MUST_HAVE_ONLY_ONE_FIELD)
             }
         } else {
@@ -111,7 +113,7 @@ mod tests {
         };
 
         ast.inner_type();
-    }
+    } // kcov-ignore
 
     #[test]
     #[should_panic(expected = "Newtype struct must only have one field.\n\
@@ -123,7 +125,7 @@ mod tests {
         };
 
         ast.inner_type();
-    }
+    } // kcov-ignore
 
     #[test]
     fn inner_type_mut_returns_field() {
@@ -147,7 +149,7 @@ mod tests {
         };
 
         ast.inner_type_mut();
-    }
+    } // kcov-ignore
 
     #[test]
     #[should_panic(expected = "Newtype struct must only have one field.\n\
@@ -159,7 +161,7 @@ mod tests {
         };
 
         ast.inner_type_mut();
-    }
+    } // kcov-ignore
 
     #[test]
     fn is_newtype_returns_true_when_fields_unnamed_and_exactly_one() {

--- a/src/derive_input_struct_ext.rs
+++ b/src/derive_input_struct_ext.rs
@@ -198,7 +198,7 @@ mod tests {
         };
 
         ast.data_struct();
-    }
+    } // kcov-ignore
 
     #[test]
     fn data_struct_mut_returns_data_struct_mut() {
@@ -217,7 +217,7 @@ mod tests {
         };
 
         ast.data_struct_mut();
-    }
+    } // kcov-ignore
 
     #[test]
     fn fields_returns_unit_fields() {
@@ -237,7 +237,7 @@ mod tests {
         if let &Fields::Named(..) = ast.fields() {
             // pass
         } else {
-            panic!("Expected `fields` to return `&Fields::Named(..)")
+            panic!("Expected `fields` to return `&Fields::Named(..)") // kcov-ignore
         }
     }
 
@@ -250,7 +250,7 @@ mod tests {
         if let &Fields::Unnamed(..) = ast.fields() {
             // pass
         } else {
-            panic!("Expected `fields` to return `&Fields::Unnamed(..)")
+            panic!("Expected `fields` to return `&Fields::Unnamed(..)") // kcov-ignore
         }
     }
 
@@ -262,7 +262,7 @@ mod tests {
         };
 
         ast.fields();
-    }
+    } // kcov-ignore
 
     #[test]
     fn fields_mut_returns_unit_fields() {
@@ -282,7 +282,7 @@ mod tests {
         if let &mut Fields::Named(..) = ast.fields_mut() {
             // pass
         } else {
-            panic!("Expected `fields_mut` to return `&mut Fields::Named(..)")
+            panic!("Expected `fields_mut` to return `&mut Fields::Named(..)") // kcov-ignore
         }
     }
 
@@ -295,7 +295,7 @@ mod tests {
         if let &mut Fields::Unnamed(..) = ast.fields_mut() {
             // pass
         } else {
-            panic!("Expected `fields_mut` to return `&mut Fields::Unnamed(..)")
+            panic!("Expected `fields_mut` to return `&mut Fields::Unnamed(..)") // kcov-ignore
         }
     }
 
@@ -307,7 +307,7 @@ mod tests {
         };
 
         ast.fields_mut();
-    }
+    } // kcov-ignore
 
     #[test]
     fn fields_named_returns_named_fields() {
@@ -327,7 +327,7 @@ mod tests {
         };
 
         ast.fields_named();
-    }
+    } // kcov-ignore
 
     #[test]
     #[should_panic(expected = "This macro must be used on a struct with named fields.")]
@@ -337,7 +337,7 @@ mod tests {
         };
 
         ast.fields_named();
-    }
+    } // kcov-ignore
 
     #[test]
     fn fields_named_mut_returns_named_fields() {
@@ -357,7 +357,7 @@ mod tests {
         };
 
         ast.fields_named_mut();
-    }
+    } // kcov-ignore
 
     #[test]
     #[should_panic(expected = "This macro must be used on a struct with named fields.")]
@@ -367,7 +367,7 @@ mod tests {
         };
 
         ast.fields_named_mut();
-    }
+    } // kcov-ignore
 
     #[test]
     fn is_unit_returns_true_when_fields_unit() {
@@ -440,7 +440,7 @@ mod tests {
         };
 
         ast.assert_fields_unit();
-    }
+    } // kcov-ignore
 
     #[test]
     fn assert_fields_named_does_not_panic_when_fields_named() {
@@ -459,7 +459,7 @@ mod tests {
         };
 
         ast.assert_fields_named();
-    }
+    } // kcov-ignore
 
     #[test]
     fn assert_fields_unnamed_does_not_panic_when_fields_unnamed() {
@@ -478,5 +478,5 @@ mod tests {
         };
 
         ast.assert_fields_unnamed();
-    }
+    } // kcov-ignore
 }

--- a/src/field_ext.rs
+++ b/src/field_ext.rs
@@ -66,6 +66,7 @@ impl FieldExt for Field {
                 return ident;
             }
         }
+        // kcov-ignore-start
         panic!(
             "Expected {}field type to be a `Path` with a segment.",
             self.ident
@@ -73,6 +74,7 @@ impl FieldExt for Field {
                 .map(|ident| format!("`{:?}` ", ident))
                 .unwrap_or_else(|| String::from(""))
         );
+        // kcov-ignore-end
     }
 
     fn is_phantom_data(&self) -> bool {
@@ -176,7 +178,7 @@ mod tests {
 
                     assert!(
                         !field.contains_tag("my_derive", "tag_name"),
-                        assertion_message
+                        assertion_message // kcov-ignore
                     );
 
                     Ok(())
@@ -238,7 +240,7 @@ mod tests {
 
                     assert!(
                         !field.contains_tag("my_derive", "tag_name"),
-                        assertion_message
+                        assertion_message // kcov-ignore
                     );
 
                     Ok(())

--- a/src/field_ext.rs
+++ b/src/field_ext.rs
@@ -1,0 +1,248 @@
+use syn::{
+    punctuated::Pair, Attribute, Field, Ident, Meta, NestedMeta, PathSegment, Type, TypePath,
+};
+
+/// Functions to make it ergonomic to inspect `Field`s and their attributes.
+pub trait FieldExt {
+    /// Returns whether a field contains a given `#[namespace(tag)]` attribute.
+    ///
+    /// # Parameters
+    ///
+    /// * `namespace`: The `name()` of the first-level attribute.
+    /// * `tag`: The `name()` of the second-level attribute.
+    fn contains_tag<NS, Tag>(&self, namespace: NS, tag: Tag) -> bool
+    where
+        Ident: PartialEq<NS>,
+        Ident: PartialEq<Tag>;
+
+    /// Returns the simple type name of a field.
+    ///
+    /// For example, the `PhantomData` in `std::marker::PhantomData<T>`.
+    fn type_name(&self) -> &Ident;
+
+    /// Returns whether the field is `PhantomData`.
+    ///
+    /// Note that the detection is a string comparison instead of a type ID comparison, so is prone
+    /// to inaccurate detection, for example:
+    ///
+    /// * `use std::marker::PhantomData as GhostData;`
+    /// * `use other_crate::OtherType as PhantomData;`
+    fn is_phantom_data(&self) -> bool;
+}
+
+impl FieldExt for Field {
+    fn contains_tag<NS, Tag>(&self, namespace: NS, tag: Tag) -> bool
+    where
+        Ident: PartialEq<NS>,
+        Ident: PartialEq<Tag>,
+    {
+        self.attrs
+            .iter()
+            .map(Attribute::parse_meta)
+            .filter_map(Result::ok)
+            .filter(|meta| meta.name() == namespace)
+            .any(|meta| {
+                if let Meta::List(meta_list) = meta {
+                    meta_list
+                        .nested
+                        .iter()
+                        .filter_map(|nested_meta| {
+                            if let NestedMeta::Meta(meta) = nested_meta {
+                                Some(meta)
+                            } else {
+                                None
+                            }
+                        })
+                        .any(|meta| meta.name() == tag)
+                } else {
+                    false
+                }
+            })
+    }
+
+    fn type_name(&self) -> &Ident {
+        if let Type::Path(TypePath { path, .. }) = &self.ty {
+            if let Some(Pair::End(PathSegment { ident, .. })) = path.segments.last() {
+                return ident;
+            }
+        }
+        panic!(
+            "Expected {}field type to be a `Path` with a segment.",
+            self.ident
+                .as_ref()
+                .map(|ident| format!("`{:?}` ", ident))
+                .unwrap_or_else(|| String::from(""))
+        );
+    }
+
+    fn is_phantom_data(&self) -> bool {
+        self.type_name() == "PhantomData"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use syn::{parse_quote, Fields, FieldsNamed};
+
+    use super::FieldExt;
+
+    #[test]
+    fn type_name_returns_simple_type_name() {
+        let fields_named: FieldsNamed = parse_quote! {{
+            #[my_derive(tag_name)]
+            pub name: PhantomData<T>,
+        }};
+        let fields = Fields::from(fields_named);
+        let field = fields.iter().next().expect("Expected field to exist.");
+
+        assert_eq!(field.type_name(), "PhantomData");
+    }
+
+    #[test]
+    fn is_phantom_data_returns_true_for_phantom_data() {
+        let fields_named: FieldsNamed = parse_quote! {{
+            #[my_derive(tag_name)]
+            pub name: PhantomData<T>,
+        }};
+        let fields = Fields::from(fields_named);
+        let field = fields.iter().next().expect("Expected field to exist.");
+
+        assert!(field.is_phantom_data());
+    }
+
+    #[test]
+    fn is_phantom_data_returns_false_for_non_phantom_data() {
+        let fields_named: FieldsNamed = parse_quote! {{
+            #[my_derive(tag_name)]
+            pub name: GhostData<T>,
+        }};
+        let fields = Fields::from(fields_named);
+        let field = fields.iter().next().expect("Expected field to exist.");
+
+        assert!(!field.is_phantom_data());
+    }
+
+    mod fields_named {
+        use proc_macro2::Span;
+        use quote::quote;
+        use syn::{parse_quote, Error, Fields, FieldsNamed};
+
+        use super::super::FieldExt;
+
+        #[test]
+        fn contains_tag_returns_true_when_tag_exists() -> Result<(), Error> {
+            let fields_named: FieldsNamed = parse_quote! {{
+                #[my_derive(tag_name)]
+                pub name: PhantomData,
+            }};
+            let fields = Fields::from(fields_named);
+            let field = fields.iter().next().expect("Expected field to exist.");
+
+            assert!(field.contains_tag("my_derive", "tag_name"));
+
+            Ok(())
+        }
+
+        #[test]
+        fn contains_tag_returns_false_when_tag_does_not_exist() -> Result<(), Error> {
+            let tokens_list = vec![
+                quote! {{
+                    #[my_derive]
+                    pub name: PhantomData,
+                }},
+                quote! {{
+                    #[my_derive(other)]
+                    pub name: PhantomData,
+                }},
+                quote! {{
+                    #[other(tag_name)]
+                    pub name: PhantomData,
+                }},
+            ];
+
+            tokens_list
+                .into_iter()
+                .try_for_each(|tokens| -> Result<(), Error> {
+                    let message = format!("Failed to parse tokens: `{}`", &tokens);
+                    let assertion_message = format!(
+                        "Expected `contains_tag` to return false for tokens: `{}`",
+                        &tokens
+                    );
+
+                    let fields_named: FieldsNamed =
+                        syn::parse2(tokens).map_err(|_| Error::new(Span::call_site(), &message))?;
+                    let fields = Fields::from(fields_named);
+                    let field = fields.iter().next().expect("Expected field to exist.");
+
+                    assert!(
+                        !field.contains_tag("my_derive", "tag_name"),
+                        assertion_message
+                    );
+
+                    Ok(())
+                })
+        }
+    }
+
+    mod fields_unnamed {
+        use proc_macro2::Span;
+        use quote::quote;
+        use syn::{parse_quote, Error, Fields, FieldsUnnamed};
+
+        use super::super::FieldExt;
+
+        #[test]
+        fn contains_tag_returns_true_when_tag_exists() -> Result<(), Error> {
+            let fields_unnamed: FieldsUnnamed = parse_quote! {(
+                #[my_derive(tag_name)]
+                pub PhantomData,
+            )};
+            let fields = Fields::from(fields_unnamed);
+            let field = fields.iter().next().expect("Expected field to exist.");
+
+            assert!(field.contains_tag("my_derive", "tag_name"));
+
+            Ok(())
+        }
+
+        #[test]
+        fn contains_tag_returns_false_when_tag_does_not_exist() -> Result<(), Error> {
+            let tokens_list = vec![
+                quote! {(
+                    #[my_derive]
+                    pub PhantomData,
+                )},
+                quote! {(
+                    #[my_derive(other)]
+                    pub PhantomData,
+                )},
+                quote! {(
+                    #[other(tag_name)]
+                    pub PhantomData,
+                )},
+            ];
+
+            tokens_list
+                .into_iter()
+                .try_for_each(|tokens| -> Result<(), Error> {
+                    let message = format!("Failed to parse tokens: `{}`", &tokens);
+                    let assertion_message = format!(
+                        "Expected `contains_tag` to return false for tokens: `{}`",
+                        &tokens
+                    );
+
+                    let fields_unnamed: FieldsUnnamed =
+                        syn::parse2(tokens).map_err(|_| Error::new(Span::call_site(), &message))?;
+                    let fields = Fields::from(fields_unnamed);
+                    let field = fields.iter().next().expect("Expected field to exist.");
+
+                    assert!(
+                        !field.contains_tag("my_derive", "tag_name"),
+                        assertion_message
+                    );
+
+                    Ok(())
+                })
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,11 +172,52 @@
 //!     assert_eq!(Ident::new("TwoOne", Span::call_site()), one.prepend(&two));
 //!     # }
 //!     ```
+//!
+//! 6. Accessing struct fields.
+//!
+//!     ```rust,edition2018
+//!     use proc_macro_roids::DeriveInputStructExt;
+//!     use syn::{parse_quote, DeriveInput, Fields};
+//!
+//!     # fn main() {
+//!     let ast: DeriveInput = parse_quote! {
+//!         struct Named {}
+//!     };
+//!
+//!     if let Fields::Named(..) = ast.fields() {
+//!         // do something
+//!     }
+//!     # }
+//!     ```
+//!
+//! 7. Inspecting `Field`s.
+//!
+//!     ```rust,edition2018
+//!     use proc_macro_roids::FieldExt;
+//!     use syn::{parse_quote, Fields, FieldsNamed};
+//!
+//!     # fn main() {
+//!     let fields_named: FieldsNamed = parse_quote! {{
+//!         #[my_derive(tag_name)]
+//!         pub name: PhantomData<T>,
+//!     }};
+//!     let fields = Fields::from(fields_named);
+//!     let field = fields.iter().next().expect("Expected field to exist.");
+//!
+//!     assert_eq!(field.type_name(), "PhantomData");
+//!     assert!(field.is_phantom_data());
+//!     assert!(field.contains_tag("my_derive", "tag_name"));
+//!     # }
+//!     ```
+
+#[cfg(test)]
+extern crate proc_macro;
 
 pub use crate::{
     derive_input_derive_ext::DeriveInputDeriveExt,
     derive_input_newtype_ext::DeriveInputNewtypeExt,
     derive_input_struct_ext::DeriveInputStructExt,
+    field_ext::FieldExt,
     fields_named_append::FieldsNamedAppend,
     fields_unnamed_append::FieldsUnnamedAppend,
     ident_ext::IdentExt,
@@ -186,6 +227,7 @@ pub use crate::{
 mod derive_input_derive_ext;
 mod derive_input_newtype_ext;
 mod derive_input_struct_ext;
+mod field_ext;
 mod fields_named_append;
 mod fields_unnamed_append;
 mod ident_ext;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,70 @@
 //! The *roids* name is chosen because, although these functions make it easy to perform certain
 //! operation, they may not necessarily be a good idea =D!
 //!
+//! Makes writing procedural macros much easier:
+//!
+//! ```rust,ignore
+//! extern crate proc_macro;
+//!
+//! use proc_macro::TokenStream;
+//! use proc_macro2::Span;
+//! use proc_macro_roids::{DeriveInputStructExt, FieldExt, IdentExt};
+//! use quote::quote;
+//! use syn::{parse_macro_input, DeriveInput, Ident};
+//!
+//! /// Derives a `Super` implementation:
+//! ///
+//! /// ```rust,edition2018
+//! /// use std::marker::PhantomData;
+//! /// use super_derive::Super;
+//! ///
+//! /// #[derive(Super)]
+//! /// pub struct Man<T> {
+//! ///     #[super_derive(skip)]
+//! ///     name: String,
+//! ///     power_level: u64,
+//! ///     marker: PhantomData<T>,
+//! /// }
+//! /// ```
+//! ///
+//! /// Generates:
+//! ///
+//! /// ```rust,ignore
+//! /// pub enum SuperMan {
+//! ///     U64(u64),
+//! /// }
+//! /// ```
+//! #[proc_macro_derive(Super, attributes(super_derive))]
+//! pub fn system_desc_derive(input: TokenStream) -> TokenStream {
+//!     let ast = parse_macro_input!(input as DeriveInput);
+//!     let enum_name = ast.ident.prepend("Super");
+//!     let fields = ast.fields();
+//!     let relevant_fields = fields
+//!         .iter()
+//!         .filter(|field| !field.is_phantom_data())
+//!         .filter(|field| !field.contains_tag("super_derive", "skip"));
+//!
+//!     let variants = relevant_fields
+//!         .map(|field| {
+//!             let type_name = field.type_name();
+//!             let variant_name = type_name.to_string().to_uppercase();
+//!             let variant_name = Ident::new(&variant_name, Span::call_site());
+//!             quote! {
+//!                 #variant_name(#type_name)
+//!             }
+//!         })
+//!         .collect::<Vec<_>>();
+//!
+//!     let token_stream2 = quote! {
+//!         pub enum #enum_name {
+//!             #(#variants,)*
+//!         }
+//!     };
+//!
+//!     token_stream2.into()
+//! }
+//! ```
+//!
 //! # Examples
 //!
 //! 1. Append additional `#[derive(..)]`s.


### PR DESCRIPTION
Implements `FieldExt`:

```rust
let fields_named: FieldsNamed = parse_quote! {{
    #[my_derive(tag_name)]
    pub name: PhantomData<T>,
}};
let fields = Fields::from(fields_named);
let field = fields.iter().next().expect("Expected field to exist.");

assert_eq!(field.type_name(), "PhantomData");
assert!(field.is_phantom_data());
assert!(field.contains_tag("my_derive", "tag_name"));
```
