### PR TITLE
Feature/return nested meta attr params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.0 (unreleased)
+
+* ***Breaking:*** `DeriveInputExt::tag_parameter` and `DeriveInputExt::tag_parameters` return `NestedMeta`.
+* ***Breaking:*** `FieldExt::tag_parameter` and `FieldExt::tag_parameters` return `NestedMeta`.
+* `util::tag_parameter` and `util::tag_parameters` are now `pub`.
+* `util::namespace_meta_list` is now `pub`.
+* `util::tag_meta_list` and `util::tag_meta_list_owned` are now `pub`.
+
 ## 0.5.0 (2019-08-19)
 
 * `syn`, `quote`, and `proc_macro2` are upgraded to `1.0`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,16 +5,16 @@ name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ctor"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -27,7 +27,7 @@ name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -36,22 +36,14 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ctor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -62,17 +54,9 @@ name = "proc_macro_roids"
 version = "0.5.0"
 dependencies = [
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "quote"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -80,33 +64,18 @@ name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "0.15.29"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-xid"
@@ -115,7 +84,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -134,18 +103,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum ctor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "e5cc1c7c759bf979c651ce1da82d06065375e2223b65c070190b8000787da58b"
+"checksum ctor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3e061727ebef83bbccac7c27b9a5ff9fd83094d34cb20f4005440a9562a27de7"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 "checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
-"checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
-"checksum proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c5c2380ae88876faae57698be9e9775e3544decad214599c3a6266cca6ac802"
-"checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
+"checksum proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afdc77cc74ec70ed262262942ebb7dac3d479e9e5cfa2da1841c0806f6cdabcc"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
-"checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
-"checksum syn 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "158521e6f544e7e3dcfc370ac180794aa38cb34a1b1e07609376d4adcf429b93"
-"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
+"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ keywords = ["proc_macro", "macros"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-proc-macro2 = "1.0.1"
+proc-macro2 = "1.0.4"
 quote = "1.0.2"
-syn = { version = "1.0.3", features = ["extra-traits", "visit"] }
+syn = { version = "1.0.5", features = ["extra-traits", "visit"] }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/src/derive_input_ext.rs
+++ b/src/derive_input_ext.rs
@@ -42,7 +42,7 @@ pub trait DeriveInputExt {
     ///
     /// * `namespace`: The `path()` of the first-level attribute.
     /// * `tag`: The `path()` of the second-level attribute.
-    fn tag_parameters(&self, namespace: &Path, tag: &Path) -> Vec<Meta>;
+    fn tag_parameters(&self, namespace: &Path, tag: &Path) -> Vec<NestedMeta>;
 }
 
 impl DeriveInputExt for DeriveInput {
@@ -99,7 +99,7 @@ impl DeriveInputExt for DeriveInput {
         util::tag_parameter(&self.attrs, namespace, tag)
     }
 
-    fn tag_parameters(&self, namespace: &Path, tag: &Path) -> Vec<Meta> {
+    fn tag_parameters(&self, namespace: &Path, tag: &Path) -> Vec<NestedMeta> {
         util::tag_parameters(&self.attrs, namespace, tag)
     }
 }
@@ -107,7 +107,7 @@ impl DeriveInputExt for DeriveInput {
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
-    use syn::{parse_quote, DeriveInput, Meta};
+    use syn::{parse_quote, DeriveInput, Lit, Meta, NestedMeta};
 
     use super::DeriveInputExt;
 
@@ -207,22 +207,22 @@ mod tests {
 
         assert_eq!(
             ast.tag_parameters(&parse_quote!(my::derive), &parse_quote!(tag::name)),
-            Vec::<Meta>::new()
+            Vec::<NestedMeta>::new()
         );
     }
 
     #[test]
     fn tag_parameters_returns_idents_when_present() {
         let ast: DeriveInput = parse_quote!(
-            #[my::derive(tag::name(Magic::One, Magic::Two))]
+            #[my::derive(tag::name(Magic::One, "{ Magic::Two }"))]
             struct Struct;
         );
 
         assert_eq!(
             ast.tag_parameters(&parse_quote!(my::derive), &parse_quote!(tag::name)),
             vec![
-                Meta::Path(parse_quote!(Magic::One)),
-                Meta::Path(parse_quote!(Magic::Two)),
+                NestedMeta::Meta(Meta::Path(parse_quote!(Magic::One))),
+                NestedMeta::Lit(Lit::Str(parse_quote!("{ Magic::Two }"))),
             ]
         );
     }

--- a/src/derive_input_ext.rs
+++ b/src/derive_input_ext.rs
@@ -34,7 +34,7 @@ pub trait DeriveInputExt {
     /// # Panics
     ///
     /// Panics if there is more than one parameter for the tag.
-    fn tag_parameter(&self, namespace: &Path, tag: &Path) -> Option<Meta>;
+    fn tag_parameter(&self, namespace: &Path, tag: &Path) -> Option<NestedMeta>;
 
     /// Returns the parameters from `#[namespace(tag(param1, param2, ..))]`.
     ///
@@ -95,7 +95,7 @@ impl DeriveInputExt for DeriveInput {
         }
     }
 
-    fn tag_parameter(&self, namespace: &Path, tag: &Path) -> Option<Meta> {
+    fn tag_parameter(&self, namespace: &Path, tag: &Path) -> Option<NestedMeta> {
         util::tag_parameter(&self.attrs, namespace, tag)
     }
 
@@ -181,7 +181,7 @@ mod tests {
 
         assert_eq!(
             ast.tag_parameter(&parse_quote!(my::derive), &parse_quote!(tag::name)),
-            Some(Meta::Path(parse_quote!(Magic)))
+            Some(NestedMeta::Meta(Meta::Path(parse_quote!(Magic))))
         );
     }
 

--- a/src/field_ext.rs
+++ b/src/field_ext.rs
@@ -44,7 +44,7 @@ pub trait FieldExt {
     ///
     /// * `namespace`: The `path()` of the first-level attribute.
     /// * `tag`: The `path()` of the second-level attribute.
-    fn tag_parameters(&self, namespace: &Path, tag: &Path) -> Vec<Meta>;
+    fn tag_parameters(&self, namespace: &Path, tag: &Path) -> Vec<NestedMeta>;
 }
 
 impl FieldExt for Field {
@@ -98,14 +98,14 @@ impl FieldExt for Field {
         util::tag_parameter(&self.attrs, namespace, tag)
     }
 
-    fn tag_parameters(&self, namespace: &Path, tag: &Path) -> Vec<Meta> {
+    fn tag_parameters(&self, namespace: &Path, tag: &Path) -> Vec<NestedMeta> {
         util::tag_parameters(&self.attrs, namespace, tag)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use syn::{parse_quote, Fields, FieldsNamed, Meta};
+    use syn::{parse_quote, Fields, FieldsNamed, Lit, Meta, NestedMeta};
 
     use super::FieldExt;
 
@@ -196,14 +196,14 @@ mod tests {
 
         assert_eq!(
             field.tag_parameters(&parse_quote!(my::derive), &parse_quote!(tag::name)),
-            Vec::<Meta>::new()
+            Vec::<NestedMeta>::new()
         );
     }
 
     #[test]
     fn tag_parameters_returns_paths_when_present() {
         let fields_named: FieldsNamed = parse_quote! {{
-            #[my::derive(tag::name(Magic::One, Magic::Two))]
+            #[my::derive(tag::name(Magic::One, "{ Magic::Two }"))]
             pub name: u32,
         }};
         let fields = Fields::from(fields_named);
@@ -212,8 +212,8 @@ mod tests {
         assert_eq!(
             field.tag_parameters(&parse_quote!(my::derive), &parse_quote!(tag::name)),
             vec![
-                Meta::Path(parse_quote!(Magic::One)),
-                Meta::Path(parse_quote!(Magic::Two)),
+                NestedMeta::Meta(Meta::Path(parse_quote!(Magic::One))),
+                NestedMeta::Lit(Lit::Str(parse_quote!("{ Magic::Two }"))),
             ]
         );
     }

--- a/src/field_ext.rs
+++ b/src/field_ext.rs
@@ -36,7 +36,7 @@ pub trait FieldExt {
     /// # Panics
     ///
     /// Panics if there is more than one parameter for the tag.
-    fn tag_parameter(&self, namespace: &Path, tag: &Path) -> Option<Meta>;
+    fn tag_parameter(&self, namespace: &Path, tag: &Path) -> Option<NestedMeta>;
 
     /// Returns the parameters from `#[namespace(tag(param1, param2, ..))]`.
     ///
@@ -94,7 +94,7 @@ impl FieldExt for Field {
             })
     }
 
-    fn tag_parameter(&self, namespace: &Path, tag: &Path) -> Option<Meta> {
+    fn tag_parameter(&self, namespace: &Path, tag: &Path) -> Option<NestedMeta> {
         util::tag_parameter(&self.attrs, namespace, tag)
     }
 
@@ -166,7 +166,7 @@ mod tests {
 
         assert_eq!(
             field.tag_parameter(&parse_quote!(my::derive), &parse_quote!(tag::name)),
-            Some(Meta::Path(parse_quote!(Magic)))
+            Some(NestedMeta::Meta(Meta::Path(parse_quote!(Magic))))
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,8 +298,8 @@ pub use crate::{
     fields_unnamed_append::FieldsUnnamedAppend,
     ident_ext::IdentExt,
     util::{
-        format_path, ident_concat, meta_list_contains, nested_meta_to_path, tag_parameter,
-        tag_parameters,
+        format_path, ident_concat, meta_list_contains, namespace_meta_lists, nested_meta_to_path,
+        tag_meta_list, tag_meta_list_owned, tag_parameter, tag_parameters,
     },
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,7 @@
 //!     ```rust,edition2018
 //!     use proc_macro_roids::FieldExt;
 //!     use proc_macro2::Span;
-//!     use syn::{parse_quote, Fields, FieldsNamed, Lit, LitStr, Meta, MetaNameValue};
+//!     use syn::{parse_quote, Fields, FieldsNamed, Lit, LitStr, Meta, MetaNameValue, NestedMeta};
 //!
 //!     # fn main() {
 //!     let fields_named: FieldsNamed = parse_quote! {{
@@ -277,11 +277,11 @@
 //!             &parse_quote!(my::derive),
 //!             &parse_quote!(tag::name),
 //!         ).expect("Expected parameter to exist."),
-//!         Meta::NameValue(MetaNameValue {
+//!         NestedMeta::Meta(Meta::NameValue(MetaNameValue {
 //!             path: parse_quote!(param),
 //!             eq_token: Default::default(),
 //!             lit: Lit::Str(LitStr::new("value", Span::call_site())),
-//!         }),
+//!         })),
 //!     );
 //!     # }
 //!     ```


### PR DESCRIPTION
Return `NestedMeta` in tag parameters, so that downstream crates may use `Lit` parameters, not just `Meta` ones.